### PR TITLE
feat(auth): integrate login with backend service

### DIFF
--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+
+import { environment } from '../../environments/environment';
+
+export interface LoginCredentials {
+  login: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: any;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private readonly tokenKey = 'auth_token';
+  private readonly userKey = 'auth_user';
+
+  constructor(private http: HttpClient) {}
+
+  login(credentials: LoginCredentials): Observable<LoginResponse> {
+    return this.http
+      .post<LoginResponse>(`${environment.apiUrl}/login`, credentials)
+      .pipe(
+        tap((response) => {
+          this.storeToken(response.token);
+          this.storeUser(response.user);
+        })
+      );
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  getUser<T = any>(): T | null {
+    const user = localStorage.getItem(this.userKey);
+    return user ? (JSON.parse(user) as T) : null;
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.userKey);
+  }
+
+  private storeToken(token: string): void {
+    localStorage.setItem(this.tokenKey, token);
+  }
+
+  private storeUser(user: any): void {
+    localStorage.setItem(this.userKey, JSON.stringify(user));
+  }
+}

--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
-import { Router, RouterModule } from '@angular/router'; // Added RouterModule for routerLink
+import { Router, RouterModule } from '@angular/router';
+
+import { AuthService } from '../auth.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterModule], // Added RouterModule
+  imports: [CommonModule, FormsModule, RouterModule],
   templateUrl: './login.html',
   styleUrls: ['./login.css']
 })
@@ -16,7 +17,7 @@ export class LoginComponent {
   password: string = '';
   error: string | null = null;
 
-  constructor(private http: HttpClient, private router: Router) {}
+  constructor(private authService: AuthService, private router: Router) {}
 
   login() {
     this.error = null;
@@ -25,22 +26,24 @@ export class LoginComponent {
       return;
     }
 
-    // --- MOCK LOGIN LOGIC (Replace with backend API later) ---
-    if (this.username === 'admin' && this.password === 'adminpass') {
-      console.log('Admin Login Successful (Mock)');
-      this.router.navigate(['/admin/dashboard']);
-    } else if (this.username === 'staff1' && this.password === 'staffpass1') {
-      console.log('Staff Login 1 Successful (Mock)');
-      this.router.navigate(['/staff/dashboard']);
-    } else if (this.username === 'staff2' && this.password === 'staffpass2') {
-      console.log('Staff Login 2 Successful (Mock)');
-      this.router.navigate(['/staff/dashboard']);
-    } else if (this.username === 'Tesla_420.com' && this.password === 'Temu_123') {
-      console.log('Tejinder Successful Login (Mock)');
-      this.router.navigate(['/staff/dashboard']);
-    } else {
-      this.error = 'Invalid username or password.';
-    }
-    // --- END MOCK LOGIN LOGIC ---
+    this.authService
+      .login({ login: this.username, password: this.password })
+      .subscribe({
+        next: ({ user }) => {
+          const userGroup = user?.user_group;
+
+          if (userGroup === 'admin') {
+            this.router.navigate(['/admin/dashboard']);
+          } else if (userGroup === 'staff') {
+            this.router.navigate(['/staff/dashboard']);
+          } else {
+            this.error = 'Unknown user group.';
+          }
+        },
+        error: (error) => {
+          const message = error?.error?.message || 'Login failed. Please try again.';
+          this.error = message;
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary
- add an authentication service that calls the login API and stores the session details
- switch the login component to use the new service and route based on the returned user group
- surface API error messages in the login form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68df45344e18832ba34455dd9a92ae2b