### PR TITLE
feat: secure staff and admin routes

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -9,12 +9,13 @@
 
 import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { routes } from './app.routes'; // <-- Import routes here
+import { authInterceptor } from './auth/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor]))
   ]
 };

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -129,6 +129,7 @@ import { WorkHistoryComponent } from './staff/work-history/work-history';
 import { LoginComponent } from './auth/login/login';
 import { ForgotPasswordComponent } from './auth/forgot-password/forgot-password';
 import { ResetPasswordComponent } from './auth/reset-password/reset-password';
+import { authGuard } from './auth/auth.guard';
 
 // Admin
 import { AdminDashboardComponent } from './admin/dashboard/admin-dashboard';
@@ -151,25 +152,70 @@ export const routes: Routes = [
   { path: 'terms', component: TermsAndConditionsComponent },
   { path: 'search', component: SearchComponent },
   { path: 'contact', component: Contact },
-  { path: 'staff/work-history', component: WorkHistoryComponent },
-  { path: 'staff/report', component: StaffReportComponent },
+
   // Auth
   { path: 'login', component: LoginComponent },
   { path: 'forgot-password', component: ForgotPasswordComponent },
   { path: 'reset-password', component: ResetPasswordComponent },
 
   // Admin
-  { path: 'admin/dashboard', component: AdminDashboardComponent },
-  { path: 'admin/staff-management', component: StaffManagementComponent },
-  { path: 'admin/staff-activity', component: StaffActivityComponent },
-  { path: 'admin/timesheet-review', component: TimesheetReviewComponent },
+  {
+    path: 'admin/dashboard',
+    component: AdminDashboardComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'admin/staff-management',
+    component: StaffManagementComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'admin/staff-activity',
+    component: StaffActivityComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'admin/timesheet-review',
+    component: TimesheetReviewComponent,
+    canActivate: [authGuard]
+  },
 
   // Staff
-  { path: 'staff/dashboard', component: StaffDashboardComponent },
-  { path: 'staff/enquiries', component: EnquiriesComponent },
-  { path: 'staff/quotes-bookings', component: QuotesBookingsComponent },
-  { path: 'staff/customer-enquiries', component: CustomerEnquiriesComponent },
-  { path: 'staff/timesheet', component: StaffTimesheetComponent },
+  {
+    path: 'staff/dashboard',
+    component: StaffDashboardComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/enquiries',
+    component: EnquiriesComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/quotes-bookings',
+    component: QuotesBookingsComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/customer-enquiries',
+    component: CustomerEnquiriesComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/timesheet',
+    component: StaffTimesheetComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/work-history',
+    component: WorkHistoryComponent,
+    canActivate: [authGuard]
+  },
+  {
+    path: 'staff/report',
+    component: StaffReportComponent,
+    canActivate: [authGuard]
+  }
 
   // Default
   //{ path: '', redirectTo: '/login', pathMatch: 'full' }

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (): boolean | UrlTree => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/src/app/auth/auth.interceptor.ts
+++ b/frontend/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,19 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { AuthService } from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const token = authService.getToken();
+
+  if (!token) {
+    return next(req);
+  }
+
+  const authReq = req.clone({
+    setHeaders: { Authorization: `Bearer ${token}` }
+  });
+
+  return next(authReq);
+};

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -34,18 +34,21 @@ export class AuthService {
       );
   }
 
-  getToken(): string | null {
-    return localStorage.getItem(this.tokenKey);
-  }
-
   getUser<T = any>(): T | null {
     const user = localStorage.getItem(this.userKey);
     return user ? (JSON.parse(user) as T) : null;
   }
 
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getToken();
+  }
+
   logout(): void {
-    localStorage.removeItem(this.tokenKey);
-    localStorage.removeItem(this.userKey);
+    this.clearStoredAuth();
   }
 
   private storeToken(token: string): void {
@@ -54,5 +57,10 @@ export class AuthService {
 
   private storeUser(user: any): void {
     localStorage.setItem(this.userKey, JSON.stringify(user));
+  }
+
+  private clearStoredAuth(): void {
+    localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.userKey);
   }
 }


### PR DESCRIPTION
## Summary
- persist the authentication token and expose helpers such as `isAuthenticated` and `logout`
- add a reusable auth guard and wire it to all admin and staff routes
- register an HTTP interceptor so API calls automatically include the bearer token

## Testing
- npm run build *(fails: bundle initial exceeded maximum budget – existing issue)*

------
https://chatgpt.com/codex/tasks/task_b_68df4aaee898832ba603634ec540317f