### PR TITLE
Add 'superadmin' group and update user deletion logic

### DIFF
--- a/backend/加入登录功能版management_api/management_api/controllerAPI/users.js
+++ b/backend/加入登录功能版management_api/management_api/controllerAPI/users.js
@@ -8,7 +8,7 @@ const d = (...args) => DEBUG_AUTH && console.log(...args);
 const de = (...args) => DEBUG_AUTH && console.error(...args);
 
 function validGroup(group) {
-  return ["admin", "staff"].includes(group);
+  return ["superadmin", "admin", "staff"].includes(group);
 }
 
 function validStatus(status) {
@@ -39,7 +39,7 @@ async function createUser(req, res) {
   if (!validGroup(user_group)) {
     return res
       .status(400)
-      .json({ ok: false, error: "user_group must be 'admin' or 'staff'" });
+      .json({ ok: false, error: "user_group must be 'superadmin', 'admin' or 'staff'" });
   }
 
   if (!validStatus(status)) {
@@ -87,8 +87,8 @@ async function deleteUser(req, res) {
     const conn = await getPool("orders").getConnection();
 
     try {
-      const [[adminCount]] = await conn.query(
-        "SELECT COUNT(*) AS c FROM users WHERE user_group='admin'"
+      const [[superadminCount]] = await conn.query(
+        "SELECT COUNT(*) AS c FROM users WHERE user_group='superadmin'"
       );
       const [[target]] = await conn.query(
         "SELECT user_group FROM users WHERE user_id=?",
@@ -99,10 +99,10 @@ async function deleteUser(req, res) {
         return res.status(404).json({ ok: false, error: "user not found" });
       }
 
-      if (target.user_group === "admin" && adminCount.c <= 1) {
+      if (target.user_group === "superadmin" && superadminCount.c <= 1) {
         return res
           .status(400)
-          .json({ ok: false, error: "cannot delete the last admin" });
+          .json({ ok: false, error: "cannot delete the last superadmin" });
       }
 
       const [result] = await conn.query("DELETE FROM users WHERE user_id=?", [

--- a/backend/加入登录功能版management_api/management_api/controllerAPI/调试日志开关TurnOnOffDebugLog_users-js.txt
+++ b/backend/加入登录功能版management_api/management_api/controllerAPI/调试日志开关TurnOnOffDebugLog_users-js.txt
@@ -1,13 +1,50 @@
 怎么开/关这些调试日志？
 
-开：PowerShell 里先执行 setx DEBUG_AUTH "1"（或当前窗口 "$env:DEBUG_AUTH='1'"），然后重启后端。
+开：PowerShell 里先执行 （或当前窗口 "$env:DEBUG_AUTH='1'"），然后重启后端。
 
 关：setx DEBUG_AUTH ""（或当前窗口清空），再重启后端。
 
 这样你随时可以用环境变量控制是否打印那些 [LOGIN] / [SQL] / [DB] 日志。
+
+
+怎么开/关日志？
+Windows（PowerShell）
+
+仅当前窗口生效：
+
+$env:DEBUG_AUTH = "1"   # 开
+# $env:DEBUG_AUTH = ""  # 关（置空）
+
+
+持久（新开窗口也生效）：
+
+setx DEBUG_AUTH "1"
+# setx DEBUG_AUTH ""   # 关
+
+
+注意：setx 对“当前这个窗口”不生效；执行后请重新打开一个终端再启动后端。
 
 PowerShell
 Turn on 	setx DEBUG_AUTH "1" 	then restart the server
 Turn off	setx DEBUG_AUTH ""	then restart the server
 
 Therefore you can use environment variable to decide if [LOGIN] / [SQL] / [DB] log will be printed
+
+查看环境变量值
+
+PowerShell：
+
+$env:DEBUG_AUTH                                   # 当前进程里的值
+[Environment]::GetEnvironmentVariable("DEBUG_AUTH","User")     # 用户范围
+[Environment]::GetEnvironmentVariable("DEBUG_AUTH","Machine")  # 机器范围
+
+
+cmd：
+
+echo %DEBUG_AUTH%     # 当前进程里的值
+set DEBUG_AUTH        # 也能看到
+
+
+Node 里直接看：
+
+node -e "console.log(process.env.DEBUG_AUTH)"


### PR DESCRIPTION
Extended valid user groups to include 'superadmin' in user creation and validation. Updated user deletion logic to prevent deleting the last 'superadmin' instead of the last 'admin'. Also expanded and clarified debug log instructions in the related documentation file.