### PR TITLE
Plan to be V2.3.1 timesheet at Admin Dashboard OK; Merge from develop, Add paginated 'My …

### DIFF
--- a/backend/加入登录功能版management_api/management_api/ljholding_backend_manage_server.js
+++ b/backend/加入登录功能版management_api/management_api/ljholding_backend_manage_server.js
@@ -273,6 +273,8 @@ r.post("/api/timesheets", Timesheets.createTimesheet);
 r.put("/api/timesheets/:timesheetId", Timesheets.updateTimesheet);
 r.post("/api/timesheets/:timesheetId/signature", Timesheets.signTimesheet);
 
+r.get("/api/my/timesheets", Timesheets.listMyTimesheets);
+
 // quotes
 
 // app.get("/api/quotes/locations", Quotes.listLocations);

--- a/frontend/src/app/admin/dashboard/admin-dashboard.html
+++ b/frontend/src/app/admin/dashboard/admin-dashboard.html
@@ -28,9 +28,9 @@
       <a class="quick-btn" routerLink="/admin/timesheets">View Timesheets</a>
     </div>
     <div class="quick-card">
-      <h3>Work History</h3>
-      <p>Browse historical shifts and worklogs.</p>
-      <a class="quick-btn" routerLink="/admin/work-history">View History</a>
+      <h3>My Timesheets</h3>
+      <p>See your previously submitted timesheets.</p>
+      <a class="quick-btn" routerLink="/admin/my-timesheets">View My History</a>
     </div>
     <div class="quick-card">
       <h3>Daily Reports</h3>

--- a/frontend/src/app/admin/timesheets/timesheet-create.html
+++ b/frontend/src/app/admin/timesheets/timesheet-create.html
@@ -35,13 +35,6 @@
         Location
         <input type="text" [(ngModel)]="form.location" name="location" placeholder="Optional" />
       </label>
-
-      <label>
-        Status
-        <select [(ngModel)]="form.status" name="status">
-          <option *ngFor="let status of statuses" [value]="status">{{ status | titlecase }}</option>
-        </select>
-      </label>
     </div>
 
     <label class="notes">
@@ -56,14 +49,6 @@
           <button type="button" class="btn link" (click)="clearEmployeeSignature()">Clear</button>
         </div>
         <canvas #employeeSigCanvas class="signature-canvas" width="400" height="160"></canvas>
-      </div>
-
-      <div class="signature-card">
-        <div class="signature-header">
-          <h3>Manager Signature</h3>
-          <button type="button" class="btn link" (click)="clearManagerSignature()">Clear</button>
-        </div>
-        <canvas #managerSigCanvas class="signature-canvas" width="400" height="160"></canvas>
       </div>
     </div>
 

--- a/frontend/src/app/admin/timesheets/timesheet-history.css
+++ b/frontend/src/app/admin/timesheets/timesheet-history.css
@@ -1,0 +1,149 @@
+.timesheet-history-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.filters-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.filter-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.filter-group label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.filter-group input {
+  padding: 8px 10px;
+  border: 1px solid #c8c8c8;
+  border-radius: 6px;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.history-table {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.history-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.history-table th,
+.history-table td {
+  border-bottom: 1px solid #e2e2e2;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+}
+
+.history-table th {
+  background: #f2f5ff;
+  text-align: left;
+}
+
+.status-tag {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  background: #eef4ff;
+  color: #0b5ed7;
+}
+
+.status-tag.status-approved {
+  background: #e8f6ec;
+  color: #2e7d32;
+}
+
+.status-tag.status-rejected {
+  background: #fdecea;
+  color: #b71c1c;
+}
+
+.status-tag.status-draft {
+  background: #f4f0ff;
+  color: #5e35b1;
+}
+
+.muted {
+  color: #6c757d;
+  text-align: center;
+}
+
+.loading {
+  padding: 8px 0;
+  color: #0b6efd;
+  font-weight: 600;
+}
+
+.alert {
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.alert-error {
+  background: #ffe6e6;
+  border: 1px solid #f0b7b7;
+  color: #7a2121;
+}
+
+.list-meta {
+  padding: 12px 0;
+  color: #4a4a4a;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+}
+
+.btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn.primary {
+  background: #0b6efd;
+  border-color: #0b6efd;
+  color: #ffffff;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/admin/timesheets/timesheet-history.html
+++ b/frontend/src/app/admin/timesheets/timesheet-history.html
@@ -1,0 +1,65 @@
+<div class="timesheet-history-container">
+  <div class="header">
+    <h1>My Timesheets</h1>
+  </div>
+
+  <section class="filters-card">
+    <div class="filter-group">
+      <label>
+        From
+        <input type="date" [(ngModel)]="filters.date_from" name="historyFrom" />
+      </label>
+      <label>
+        To
+        <input type="date" [(ngModel)]="filters.date_to" name="historyTo" />
+      </label>
+    </div>
+    <div class="filter-actions">
+      <button type="button" class="btn primary" (click)="applyFilters()">Apply</button>
+      <button type="button" class="btn" (click)="clearFilters()">Reset</button>
+    </div>
+  </section>
+
+  <div *ngIf="errorMessage" class="alert alert-error">{{ errorMessage }}</div>
+
+  <div class="history-table">
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Date</th>
+          <th>Status</th>
+          <th>Total Minutes</th>
+          <th>Location</th>
+          <th>Notes</th>
+          <th>Employee Sig</th>
+          <th>Manager Sig</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let sheet of timesheets">
+          <td>{{ sheet.timesheet_id }}</td>
+          <td>{{ sheet.work_date }}</td>
+          <td><span class="status-tag status-{{ sheet.status }}">{{ sheet.status | titlecase }}</span></td>
+          <td>{{ sheet.total_minutes ?? '—' }}</td>
+          <td>{{ sheet.location || '—' }}</td>
+          <td>{{ sheet.notes || '—' }}</td>
+          <td>{{ sheet.has_employee_signature ? '✔' : '—' }}</td>
+          <td>{{ sheet.has_manager_signature ? '✔' : '—' }}</td>
+        </tr>
+        <tr *ngIf="!timesheets.length && !isLoading">
+          <td colspan="8" class="muted">No timesheets found.</td>
+        </tr>
+      </tbody>
+    </table>
+    <div *ngIf="isLoading" class="loading">Loading timesheets…</div>
+    <div *ngIf="meta" class="list-meta">
+      Total: {{ meta.total }} | Page {{ meta.page }} / {{ meta.totalPages }}
+    </div>
+    <div *ngIf="meta && meta.totalPages > 1" class="pagination">
+      <button type="button" class="btn" (click)="prevPage()" [disabled]="currentPage <= 1">Previous</button>
+      <span>Page {{ currentPage }} of {{ meta.totalPages }}</span>
+      <button type="button" class="btn" (click)="nextPage()" [disabled]="meta && currentPage >= meta.totalPages">Next</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/admin/timesheets/timesheet-history.ts
+++ b/frontend/src/app/admin/timesheets/timesheet-history.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import {
+  TimesheetListMeta,
+  TimesheetManagementService,
+  TimesheetQuery,
+  TimesheetSummary,
+} from './timesheet-management.service';
+
+@Component({
+  selector: 'app-timesheet-history',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './timesheet-history.html',
+  styleUrls: ['./timesheet-history.css'],
+})
+export class TimesheetHistoryComponent implements OnInit {
+  filters: Pick<TimesheetQuery, 'date_from' | 'date_to'> = {};
+
+  timesheets: TimesheetSummary[] = [];
+  meta: TimesheetListMeta | null = null;
+  currentPage = 1;
+  pageSize = 20;
+
+  isLoading = false;
+  errorMessage: string | null = null;
+
+  constructor(private readonly timesheetService: TimesheetManagementService) {}
+
+  ngOnInit(): void {
+    this.loadTimesheets();
+  }
+
+  applyFilters(): void {
+    this.currentPage = 1;
+    this.loadTimesheets();
+  }
+
+  clearFilters(): void {
+    this.filters = {};
+    this.currentPage = 1;
+    this.loadTimesheets();
+  }
+
+  goToPage(page: number): void {
+    if (!this.meta) {
+      return;
+    }
+    const totalPages = this.meta.totalPages || 1;
+    const target = Math.min(Math.max(page, 1), totalPages);
+    if (target === this.currentPage) {
+      return;
+    }
+    this.currentPage = target;
+    this.loadTimesheets();
+  }
+
+  nextPage(): void {
+    if (this.meta && this.currentPage < this.meta.totalPages) {
+      this.currentPage += 1;
+      this.loadTimesheets();
+    }
+  }
+
+  prevPage(): void {
+    if (this.currentPage > 1) {
+      this.currentPage -= 1;
+      this.loadTimesheets();
+    }
+  }
+
+  private loadTimesheets(): void {
+    this.isLoading = true;
+    this.errorMessage = null;
+
+    this.timesheetService
+      .listMyTimesheets(this.currentPage, this.pageSize, this.filters)
+      .subscribe({
+        next: (result) => {
+          this.timesheets = result.data;
+          this.meta = result.meta;
+          this.currentPage = result.meta.page;
+          this.pageSize = result.meta.pageSize;
+          this.isLoading = false;
+        },
+        error: (err) => {
+          this.errorMessage = err instanceof Error ? err.message : 'Unable to load timesheets.';
+          this.isLoading = false;
+        }
+      });
+  }
+}

--- a/frontend/src/app/admin/timesheets/timesheet-list.css
+++ b/frontend/src/app/admin/timesheets/timesheet-list.css
@@ -84,6 +84,19 @@
   background: #e6f0ff;
 }
 
+.list-meta {
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  color: #4a4a4a;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+}
+
 .detail-panel {
   flex: 1 1 420px;
   background: #ffffff;
@@ -223,6 +236,12 @@
   background: #ffe6e6;
   border: 1px solid #f0b7b7;
   color: #7a2121;
+}
+
+.alert-success {
+  background: #e7f7eb;
+  border: 1px solid #a4d4b5;
+  color: #205b2d;
 }
 
 .btn {

--- a/frontend/src/app/admin/timesheets/timesheet-list.html
+++ b/frontend/src/app/admin/timesheets/timesheet-list.html
@@ -71,9 +71,20 @@
             <td>{{ sheet.has_employee_signature ? '✔' : '—' }}</td>
             <td>{{ sheet.has_manager_signature ? '✔' : '—' }}</td>
           </tr>
+          <tr *ngIf="!timesheets.length && !isLoadingList">
+            <td colspan="7" class="muted">No timesheets found.</td>
+          </tr>
         </tbody>
       </table>
       <div *ngIf="isLoadingList" class="loading">Loading timesheets…</div>
+      <div *ngIf="meta" class="list-meta">
+        Total: {{ meta.total }} | Page {{ meta.page }} / {{ meta.totalPages }}
+      </div>
+      <div *ngIf="meta && meta.totalPages > 1" class="pagination">
+        <button type="button" class="btn" (click)="prevPage()" [disabled]="currentPage <= 1">Previous</button>
+        <span>Page {{ currentPage }} of {{ meta.totalPages }}</span>
+        <button type="button" class="btn" (click)="nextPage()" [disabled]="meta && currentPage >= meta.totalPages">Next</button>
+      </div>
     </div>
 
     <div class="detail-panel" *ngIf="selectedTimesheet">
@@ -127,6 +138,7 @@
           <button type="button" class="btn" (click)="updateStatus('approved')" [disabled]="isSigning">Approved</button>
           <button type="button" class="btn" (click)="updateStatus('rejected')" [disabled]="isSigning">Rejected</button>
         </div>
+        <div *ngIf="statusSuccessMessage" class="alert alert-success">{{ statusSuccessMessage }}</div>
 
         <section class="signature-view">
           <h3>Existing Signatures</h3>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { TimesheetReviewComponent } from './admin/timesheet-review/timesheet-rev
 import { OrderManagementComponent } from './admin/order-management/order-management';
 import { TimesheetListComponent } from './admin/timesheets/timesheet-list';
 import { TimesheetCreateComponent } from './admin/timesheets/timesheet-create';
+import { TimesheetHistoryComponent } from './admin/timesheets/timesheet-history';
 
 import { StaffDashboardComponent } from './staff/dashboard/staff-dashboard';
 import { EnquiriesComponent } from './staff/enquiries/enquiries';
@@ -31,6 +32,7 @@ export const routes: Routes = [
   { path: 'admin/order-management', component: OrderManagementComponent, canActivate: [authGuard] },
   { path: 'admin/timesheets', component: TimesheetListComponent, canActivate: [authGuard] },
   { path: 'admin/timesheets/new', component: TimesheetCreateComponent, canActivate: [authGuard] },
+  { path: 'admin/my-timesheets', component: TimesheetHistoryComponent, canActivate: [authGuard] },
   { path: 'admin/work-history', component: WorkHistoryComponent, canActivate: [authGuard] },
   { path: 'admin/daily-reports', component: StaffReportComponent, canActivate: [authGuard] },
   { path: 'admin/staff-activity', component: StaffActivityComponent, canActivate: [authGuard] },


### PR DESCRIPTION
…Timesheets' history view

Introduces a new frontend component for users to view their own timesheet history with filters and pagination. Backend API now supports paginated timesheet listing and a dedicated endpoint for authenticated users' timesheets. Timesheet creation UI and logic are simplified, removing manager signature and status selection. Timesheet list view and service are updated for pagination and improved status feedback. Dashboard quick link updated to point to the new history view.